### PR TITLE
clock rate at 1hz instead of 0.5hz

### DIFF
--- a/04-clocks-and-procedural-assignments/solution-clock-counter/clock-counter.v
+++ b/04-clocks-and-procedural-assignments/solution-clock-counter/clock-counter.v
@@ -28,8 +28,6 @@ module clock_counter (
     reg div_clk;
     reg [31:0] count;
     localparam [31:0] max_count = 12000000 - 1;
-    
-    
 
     // Reset is the inverse of the reset button
     assign rst = ~rst_btn;

--- a/04-clocks-and-procedural-assignments/solution-clock-counter/clock-counter.v
+++ b/04-clocks-and-procedural-assignments/solution-clock-counter/clock-counter.v
@@ -27,7 +27,9 @@ module clock_counter (
     wire rst;
     reg div_clk;
     reg [31:0] count;
-    localparam [31:0] max_count = 6000000 - 1;
+    localparam [31:0] max_count = 12000000 - 1;
+    
+    
 
     // Reset is the inverse of the reset button
     assign rst = ~rst_btn;


### PR DESCRIPTION
Based on the introduction video (https://youtu.be/LwQsyeuf9Sk?t=1052) the counter should increase once per second. As far as I understand the Verilog solution operates at 0.5hz

In case this is actually no bug, sorry for misunderstanding your Verilog code, I like your introduction videos quite a lot.